### PR TITLE
fix - panic: interface conversion: interface {} is nil, not string

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -125,7 +125,8 @@ func convertFromDynamicToStaticValue(staticType reflect.Type, dynamicValue inter
 			t, _ := time.Parse(format, dynamicValue.(string))
 			staticValue = NewTime(t)
 		case "Many2One":
-			staticValue = NewMany2One(dynamicValue.([]interface{})[0].(int64), dynamicValue.([]interface{})[1].(string))
+			name, _ := dynamicValue.([]interface{})[1].(string)
+			staticValue = NewMany2One(dynamicValue.([]interface{})[0].(int64), name)
 		case "Relation":
 			staticValue = NewRelation()
 			staticValue.(*Relation).ids = sliceInterfaceToInt64Slice(dynamicValue.([]interface{}))


### PR DESCRIPTION
I encountered a panic error when tried to find custom models. These models have a reference to another model type that can have an empty name property.
```
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/skilld-labs/go-odoo.convertFromDynamicToStaticValue({0x80bf20, 0x70d100}, {0x6fc100, 0xc000a45608})
        /home/oleksiy/go/pkg/mod/github.com/!stolexiy/go-odoo@v0.0.0-20230921090116-ebb65633bbf7/conversion.go:128 +0x611
github.com/skilld-labs/go-odoo.convertFromDynamicToStaticOne(0x705dc0?, {0x80bf20, 0x750be0})
        /home/oleksiy/go/pkg/mod/github.com/!stolexiy/go-odoo@v0.0.0-20230921090116-ebb65633bbf7/conversion.go:95 +0x194
github.com/skilld-labs/go-odoo.convertFromDynamicToStaticSlice({0xc001000000, 0x10ec, 0xc0000166c0?}, {0x80bf20, 0x705dc0?})
        /home/oleksiy/go/pkg/mod/github.com/!stolexiy/go-odoo@v0.0.0-20230921090116-ebb65633bbf7/conversion.go:84 +0x70
github.com/skilld-labs/go-odoo.convertFromDynamicToStatic({0x6fc100?, 0xc000d154a0?}, {0x6f5c40?, 0xc008229c38})
        /home/oleksiy/go/pkg/mod/github.com/!stolexiy/go-odoo@v0.0.0-20230921090116-ebb65633bbf7/conversion.go:67 +0x10e
github.com/skilld-labs/go-odoo.(*Client).SearchRead(0x0?, {0x777ad8?, 0x9?}, 0xc0000c0c68?, 0x30?, {0x6f5c40, 0xc008229c38})
        /home/oleksiy/go/pkg/mod/github.com/!stolexiy/go-odoo@v0.0.0-20230921090116-ebb65633bbf7/odoo.go:282 +0x11a
github.com/skilld-labs/go-odoo.(*Client).FindXReleases(0x70a820?, 0xa01a00?, 0x3?)
        /home/oleksiy/go/pkg/mod/github.com/!stolexiy/go-odoo@v0.0.0-20230921090116-ebb65633bbf7/x_release.go:111 +0x6c
...
```