### PR TITLE
Fix Panic Error: Handle many2one_reference Field Conversion

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -129,8 +129,13 @@ func convertFromDynamicToStaticValue(staticType reflect.Type, dynamicValue inter
 			t, _ := time.Parse(format, dynamicValue.(string))
 			staticValue = NewTime(t)
 		case "Many2One":
-			name, _ := dynamicValue.([]interface{})[1].(string)
-			staticValue = NewMany2One(dynamicValue.([]interface{})[0].(int64), name)
+			if intVal, ok := dynamicValue.(int64); ok {
+				// for many2one_reference field type
+				staticValue = NewMany2One(intVal, "")
+			} else {
+				name, _ := dynamicValue.([]interface{})[1].(string)
+				staticValue = NewMany2One(dynamicValue.([]interface{})[0].(int64), name)
+			}
 		case "Relation":
 			staticValue = NewRelation()
 			staticValue.(*Relation).ids = sliceInterfaceToInt64Slice(dynamicValue.([]interface{}))


### PR DESCRIPTION
Hello,

This pull request fixes a panic error that occurs when attempting to get an entity with a field of type "many2one_reference" in a model. The "many2one_reference" field typically represents a relationship between the current model and another model in the Odoo database.

The error occurs because the conversion logic expects a slice of interfaces ([]interface{}), but in this case, it's receiving an integer (int64) instead. This fix ensures the conversion handles both scenarios correctly.

```
panic: interface conversion: interface {} is int64, not []interface {}

goroutine 1 [running]:
github.com/skilld-labs/go-odoo.convertFromDynamicToStaticValue({0x829308, 0x710d00}, {0x7038a0, 0xc000014438})
        .../vendor/github.com/skilld-labs/go-odoo/conversion.go:136 +0x5b4
github.com/skilld-labs/go-odoo.convertFromDynamicToStaticOne(0xc0002000f0, {0x829308, 0x76cd40})
        .../vendor/github.com/skilld-labs/go-odoo/conversion.go:99 +0x185
github.com/skilld-labs/go-odoo.convertFromDynamicToStaticSlice({0xc02f504000, 0xab0f, 0xc00015e230?}, {0x829308, 0x7060c0})
        .../vendor/github.com/skilld-labs/go-odoo/conversion.go:88 +0x66
github.com/skilld-labs/go-odoo.convertFromDynamicToStatic({0x6fff00, 0xc02d0bcf78}, {0x6f8bc0, 0xc00011d080})
        .../vendor/github.com/skilld-labs/go-odoo/conversion.go:71 +0x107
github.com/skilld-labs/go-odoo.(*Client).SearchRead(0xc0001ac0c0?, {0x79a72b, 0xc}, 0xc00011d038, 0x0, {0x6f8bc0, 0xc00011d080})
        .../vendor/github.com/skilld-labs/go-odoo/odoo.go:290 +0x20e
github.com/skilld-labs/go-odoo.(*Client).FindMailMessages(0xc0001ac0c0, 0xc00011d038, 0x0)
        .../vendor/github.com/skilld-labs/go-odoo/mail_message.go:139 +0x66
```